### PR TITLE
update build name for .winmd

### DIFF
--- a/OneDriveConnector/OneDriveConnector/OneDriveConnector.csproj
+++ b/OneDriveConnector/OneDriveConnector/OneDriveConnector.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{0BFF7810-2BE6-4778-A32B-E9B1B0F3982E}</ProjectGuid>
     <OutputType>winmdobj</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Microsoft.Maker.Storage.OnedriveConnector</RootNamespace>
-    <AssemblyName>Microsoft.Maker.Storage.OnedriveConnector</AssemblyName>
+    <RootNamespace>Microsoft.Maker.Storage.OneDrive</RootNamespace>
+    <AssemblyName>Microsoft.Maker.Storage.OneDrive</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion>10.0.10240.0</TargetPlatformVersion>


### PR DESCRIPTION
The current version will fail to build if you build at the solution level instead of the project level. Building the .winmd file to the new name allows it to build both at the project and the solution levels.
