### PR TITLE
Return HttpResponse Message from requests, remove exception throwing

### DIFF
--- a/OneDriveConnector/OneDriveConnector.Tests/UnitTest.cs
+++ b/OneDriveConnector/OneDriveConnector.Tests/UnitTest.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
-using Microsoft.Maker.Storage;
-using System.Net;
 using Windows.Storage;
 using System.IO;
 using System.Collections.Generic;
+using Windows.Web.Http;
 
 namespace OneDriveConnector.Tests
 {
@@ -32,21 +31,16 @@ namespace OneDriveConnector.Tests
         {
             // arrange
             var oneDriveConnector = new Microsoft.Maker.Storage.OneDrive.OneDriveConnector();
-            string receivedExceptionMessage = "";
-            string expectedExceptionMessage = "Bad request (400).\r\n\r\nResponse status code does not indicate success: 400 (Bad Request).";
+            HttpResponseMessage response;
+            HttpStatusCode receivedStatus;
+            HttpStatusCode expectedStatus = HttpStatusCode.BadRequest;
 
             //act
-            try
-            {
-                await oneDriveConnector.LoginAsync("noClientID", "noClientSecret", "noRedirectUrl", "noAccessCode");
-            }
-            catch (Exception e)
-            {
-                receivedExceptionMessage = e.Message;
-            }
+            response = await oneDriveConnector.LoginAsync("noClientID", "noClientSecret", "noRedirectUrl", "noAccessCode");
+            receivedStatus = response.StatusCode;
 
             //assert
-            Assert.AreEqual(expectedExceptionMessage, receivedExceptionMessage);
+            Assert.AreEqual(expectedStatus, receivedStatus);
         }
 
         [TestMethod]
@@ -55,21 +49,16 @@ namespace OneDriveConnector.Tests
             // arrange
             var oneDriveConnector = new Microsoft.Maker.Storage.OneDrive.OneDriveConnector();
             StorageFile file = await ApplicationData.Current.TemporaryFolder.CreateFileAsync("test.test", CreationCollisionOption.ReplaceExisting);
-            string receivedExceptionMessage = "";
-            string expectedExceptionMessage = "Unauthorized (401).\r\n\r\nResponse status code does not indicate success: 401 (Unauthorized).";
+            HttpResponseMessage response;
+            HttpStatusCode receivedStatus;
+            HttpStatusCode expectedStatus = HttpStatusCode.Unauthorized;
 
             //act
-            try
-            {
-                await oneDriveConnector.UploadFileAsync(file, "");
-            }
-            catch (Exception e)
-            {
-                receivedExceptionMessage = e.Message;
-            }
+            response = await oneDriveConnector.UploadFileAsync(file, "");
+            receivedStatus = response.StatusCode;
 
             //assert
-            Assert.AreEqual(expectedExceptionMessage, receivedExceptionMessage);
+            Assert.AreEqual(expectedStatus, receivedStatus);
         }
 
         [TestMethod]
@@ -77,23 +66,17 @@ namespace OneDriveConnector.Tests
         {
             // arrange
             var oneDriveConnector = new Microsoft.Maker.Storage.OneDrive.OneDriveConnector();
+            KeyValuePair<HttpResponseMessage, IList<string>> response;
             IList<string> list;
-            string receivedExceptionMessage = "";
-            string expectedExceptionMessage = "Unauthorized (401).\r\n\r\nResponse status code does not indicate success: 401 (Unauthorized).";
+            HttpStatusCode receivedStatus;
+            HttpStatusCode expectedStatus = HttpStatusCode.Unauthorized;
 
             //act
-            try
-            {
-                var response = await oneDriveConnector.ListFilesAsync("");
-                list = response.Value;
-            }
-            catch (Exception e)
-            {
-                receivedExceptionMessage = e.Message;
-            }
+            response = await oneDriveConnector.ListFilesAsync("");
+            receivedStatus = response.Key.StatusCode;
 
             //assert
-            Assert.AreEqual(expectedExceptionMessage, receivedExceptionMessage);
+            Assert.AreEqual(expectedStatus, receivedStatus);
         }
 
         [TestMethod]
@@ -101,21 +84,16 @@ namespace OneDriveConnector.Tests
         {
             // arrange
             var oneDriveConnector = new Microsoft.Maker.Storage.OneDrive.OneDriveConnector();
-            string receivedExceptionMessage = "";
-            string expectedExceptionMessage = "Unauthorized (401).\r\n\r\nResponse status code does not indicate success: 401 (Unauthorized).";
+            HttpResponseMessage response;
+            HttpStatusCode receivedStatus;
+            HttpStatusCode expectedStatus = HttpStatusCode.Unauthorized;
 
             //act
-            try
-            {
-                await oneDriveConnector.DeleteFileAsync("name", "");
-            }
-            catch (Exception e)
-            {
-                receivedExceptionMessage = e.Message;
-            }
+            response = await oneDriveConnector.DeleteFileAsync("name", "");
+            receivedStatus = response.StatusCode;
 
             //assert
-            Assert.AreEqual(expectedExceptionMessage, receivedExceptionMessage);
+            Assert.AreEqual(expectedStatus, receivedStatus);
         }
     }
 }

--- a/OneDriveConnector/OneDriveConnector.Tests/UnitTest.cs
+++ b/OneDriveConnector/OneDriveConnector.Tests/UnitTest.cs
@@ -84,7 +84,8 @@ namespace OneDriveConnector.Tests
             //act
             try
             {
-                list = await oneDriveConnector.ListFilesAsync("");
+                var response = await oneDriveConnector.ListFilesAsync("");
+                list = response.Value;
             }
             catch (Exception e)
             {

--- a/OneDriveConnector/OneDriveConnector/OneDriveConnector.cs
+++ b/OneDriveConnector/OneDriveConnector/OneDriveConnector.cs
@@ -178,7 +178,6 @@ namespace Microsoft.Maker.Storage.OneDrive
                 {               
                     using (HttpResponseMessage response = await httpClient.SendRequestAsync(requestMessage))
                     {
-                        response.EnsureSuccessStatusCode();
                         IList<string> files = new List<string>();
                         using (var inputStream = await response.Content.ReadAsInputStreamAsync())
                         {
@@ -268,7 +267,6 @@ namespace Microsoft.Maker.Storage.OneDrive
                 requestMessage.Content.Headers.ContentType = new HttpMediaTypeHeaderValue("application/x-www-form-urlencoded");
                 using (HttpResponseMessage responseMessage = await httpClient.SendRequestAsync(requestMessage))
                 {
-                    responseMessage.EnsureSuccessStatusCode();
                     string responseContentString = await responseMessage.Content.ReadAsStringAsync();
                     accessToken = GetAccessToken(responseContentString);
                     refreshToken = GetRefreshToken(responseContentString);


### PR DESCRIPTION
Instead of throwing an exception on a bad HttpResponseMessage status, the response message is now returned to the caller, who can check the status and act appropriately. This is needed because the thrown exception for bad http status does not include the status code in an format except as part of a description string. 

This change thus allows the callers to more easily determine the status of the request, and to act more appropriately on that statues (retry request, prompt user for reauth, throw an exception, etc).
